### PR TITLE
[ci] add github actions for osm-dashboard

### DIFF
--- a/.github/workflows/cd-helm-workflow.yml
+++ b/.github/workflows/cd-helm-workflow.yml
@@ -16,7 +16,7 @@ name: Continuous Deployment - Helm
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, osm-* ]
     paths:
     - 'aio/deploy/helm-chart/**'
     - 'aio/scripts/helm-release-chart.sh'

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -16,7 +16,7 @@ name: Continuous Deployment - App
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, osm-* ]
   create:
     tags:
       - 'v*.*.*'
@@ -27,7 +27,7 @@ permissions:
 jobs:
   deploy:
     name: Development Release
-    if: github.event_name == 'push' && contains(github.ref, 'master')
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     env:
       NG_CLI_ANALYTICS: ci
@@ -35,6 +35,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
       DOCKER_CLI_EXPERIMENTAL: enabled
       TERM: xterm
+      HEAD_IMAGE: ${{secrets.HEAD_IMAGE}}
 
     steps:
       - name: Setup Environment
@@ -94,6 +95,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
       DOCKER_CLI_EXPERIMENTAL: enabled
       TERM: xterm
+      RELEASE_IMAGE: ${{secrets.RELEASE_IMAGE}}
 
     steps:
       - name: Setup Environment

--- a/.github/workflows/ci-helm-workflow.yml
+++ b/.github/workflows/ci-helm-workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cleanup charts directory
         id: cleanup
-        run: sudo rm -rf aio/deploy/helm-chart/kubernetes-dashboard/charts
+        run: sudo rm -rf aio/deploy/helm-chart/osm-dashboard/charts
 
       - name: Run chart-testing (lint)
         id: lint

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,7 +16,7 @@ name: Continuous Integration - Code
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, osm-* ]
     ignore-paths:
       - '**/*.md'
       - 'aio/deploy/**'
@@ -25,7 +25,7 @@ on:
       - '.github/workflows/cd-helm-workflow.yml'
       - '.github/workflows/cd-workflow.yml'
   pull_request:
-    branches: [ master ]
+    branches: [ master, osm-* ]
     ignore-paths:
       - '**/*.md'
       - 'aio/deploy/**'

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,14 @@ SYSTEM_BANNER_SEVERITY ?= INFO
 PROD_BINARY = dist/amd64/dashboard
 SERVE_DIRECTORY = .tmp/serve
 SERVE_BINARY = .tmp/serve/dashboard
-RELEASE_IMAGE = kubernetesui/dashboard
-RELEASE_VERSION = v2.6.0
+RELEASE_IMAGE ?= kubernetesui/dashboard
+RELEASE_VERSION ?= v2.6.0
 RELEASE_IMAGE_NAMES += $(foreach arch, $(ARCHITECTURES), $(RELEASE_IMAGE)-$(arch):$(RELEASE_VERSION))
 RELEASE_IMAGE_NAMES_LATEST += $(foreach arch, $(ARCHITECTURES), $(RELEASE_IMAGE)-$(arch):latest)
-HEAD_IMAGE = kubernetesdashboarddev/dashboard
+HEAD_IMAGE ?= kubernetesdashboarddev/dashboard
 HEAD_VERSION = latest
 HEAD_IMAGE_NAMES += $(foreach arch, $(ARCHITECTURES), $(HEAD_IMAGE)-$(arch):$(HEAD_VERSION))
-ARCHITECTURES = amd64 arm64 arm ppc64le s390x
+ARCHITECTURES = amd64 arm64 arm
 
 .PHONY: ensure-version
 ensure-version:

--- a/aio/deploy/helm-chart/osm-dashboard/.helmignore
+++ b/aio/deploy/helm-chart/osm-dashboard/.helmignore
@@ -1,0 +1,41 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS
+
+ci/

--- a/aio/deploy/helm-chart/osm-dashboard/Chart.lock
+++ b/aio/deploy/helm-chart/osm-dashboard/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: metrics-server
+  repository: https://kubernetes-sigs.github.io/metrics-server/
+  version: 3.5.0
+digest: sha256:5e472fb28387489d7ff5946178ecfa44d5fd414364906f3b5a0312ddfaabb8fd
+generated: "2021-10-05T12:13:00.705224804+02:00"

--- a/aio/deploy/helm-chart/osm-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/Chart.yaml
@@ -1,0 +1,36 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: osm-dashboard
+version: 5.5.2
+appVersion: 2.6.0
+description: General-purpose web UI for Kubernetes clusters
+keywords:
+  - kubernetes
+  - dashboard
+  - osm-edge
+home: https://github.com/flomesh-io/osm-dashboard
+sources:
+  - https://github.com/flomesh-io/osm-dashboard
+maintainers:
+  - name: desaintmartin
+    email: cdesaintmartin@wiremind.fr
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+kubeVersion: ">=1.19.0-0"
+dependencies:
+  - name: metrics-server
+    version: 3.5.0
+    repository: https://kubernetes-sigs.github.io/metrics-server/
+    condition: metrics-server.enabled

--- a/aio/deploy/helm-chart/osm-dashboard/OWNERS
+++ b/aio/deploy/helm-chart/osm-dashboard/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- desaintmartin
+reviewers:
+- desaintmartin

--- a/aio/deploy/helm-chart/osm-dashboard/README.md
+++ b/aio/deploy/helm-chart/osm-dashboard/README.md
@@ -1,0 +1,117 @@
+# kubernetes-dashboard
+
+[Kubernetes Dashboard](https://github.com/kubernetes/dashboard) is a general purpose, web-based UI for Kubernetes clusters.
+It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
+
+## TL;DR
+
+```console
+# Add kubernetes-dashboard repository
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+# Deploy a Helm Release named "kubernetes-dashboard" using the kubernetes-dashboard chart
+helm install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard
+```
+
+## Introduction
+
+This chart bootstraps a [Kubernetes Dashboard](https://github.com/kubernetes/dashboard) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the [Chart](https://helm.sh/docs/intro/using_helm/#three-big-concepts) with the [Release](https://helm.sh/docs/intro/using_helm/#three-big-concepts) name `kubernetes-dashboard`:
+
+```console
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+helm install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard
+```
+
+The command deploys kubernetes-dashboard on the Kubernetes cluster in the default configuration.
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `kubernetes-dashboard` deployment:
+
+```console
+helm delete kubernetes-dashboard
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Access control
+
+It is critical for the Kubernetes cluster to correctly setup access control of Kubernetes Dashboard.
+See this [guide](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md) for details.
+
+It is highly recommended to use RBAC with minimal privileges needed for Dashboard to run.
+
+## Configuration
+
+Please refer to [values.yaml](https://github.com/kubernetes/dashboard/blob/master/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml)
+for valid values and their defaults.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install kubernetes-dashboard/kubernetes-dashboard --name kubernetes-dashboard \
+  --set=service.externalPort=8080,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install kubernetes-dashboard/kubernetes-dashboard --name kubernetes-dashboard -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml), which is used by default, as reference
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrade from 4.x.x to 5.x.x
+
+- Switch Ingress from networking.k8s.io/v1beta1 to networking.k8s.io/v1. Requires kubernetes >= 1.19.0.
+
+### Upgrade from 2.x.x to 3.x.x
+
+- Switch Ingress from extensions/v1beta1 to networking.k8s.io/v1beta1. Requires kubernetes >= 1.14.0.
+
+### Upgrade from 1.x.x to 2.x.x
+
+Version 2.0.0 of this chart is the first version hosted in the kubernetes/dashboard.git repository. v1.x.x until 1.10.1 is hosted on https://github.com/helm/charts.
+
+- This version upgrades to kubernetes-dashboard v2.0.0 along with changes in RBAC management: all secrets are explicitely created and ServiceAccount do not have permission to create any secret. On top of that, it completely removes the `clusterAdminRole` parameter, being too dangerous. In order to upgrade, please update your configuration to remove `clusterAdminRole` parameter and uninstall/reinstall the chart.
+- It enables by default values for `podAnnotations` and `securityContext`, please disable them if you don't supoprt them
+- It removes `enableSkipLogin` and `enableInsecureLogin` parameters. Please use `extraArgs` instead.
+- It adds a `ProtocolHttp` parameter, allowing you to switch the backend to plain HTTP and replaces the old `enableSkipLogin` for the network part.
+- If `protocolHttp` is not set, it will automatically add to the `Ingress`, if enabled, annotations to support HTTPS backends for nginx-ingress and GKE Ingresses.
+- It updates all the labels to the new [recommended labels](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#names-and-labels), most of them being immutable.
+- dashboardContainerSecurityContext has been renamed to containerSecurityContext.
+
+In order to upgrade, please update your configuration to remove `clusterAdminRole` parameter and adapt `enableSkipLogin`, `enableInsecureLogin`, `podAnnotations` and `securityContext` parameters, and uninstall/reinstall the chart.
+
+### Version 4.x.x
+
+Starting from version 4.0.0 of this chart, it will only support Helm 3 and remove the support for Helm 2.
+If you still use Helm 2 you will need first to migrate the deployment to Helm 3 and then you can upgrade your chart.
+
+To do that you can follow the [guide](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
+
+## Access
+
+For information about how to access, please read the [kubernetes-dashboard manual](https://github.com/kubernetes/dashboard)
+
+### Using the dashboard with 'kubectl proxy'
+
+When running 'kubectl proxy', the address `localhost:8001/ui` automatically expands to:
+
+- `http://localhost:8001/api/v1/namespaces/my-namespace/services/https:kubernetes-dashboard:https/proxy/`
+
+For this to reach the dashboard, the name of the service must be 'kubernetes-dashboard', not any other value as set by Helm.
+You can manually specify this using the value 'fullnameOverride':
+
+```yaml
+fullnameOverride: 'kubernetes-dashboard'
+```

--- a/aio/deploy/helm-chart/osm-dashboard/ci/extra-manifests-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/extra-manifests-values.yaml
@@ -1,0 +1,7 @@
+extraManifests:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: additional-configmap
+  data:
+    mykey: myvalue

--- a/aio/deploy/helm-chart/osm-dashboard/ci/ingress-customPaths-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/ingress-customPaths-values.yaml
@@ -1,0 +1,17 @@
+ingress:
+  enabled: true
+
+  customPaths:
+    - pathType: ImplementationSpecific
+      backend:
+        service:
+          name: ssl-redirect
+          port:
+            name: use-annotation
+    - pathType: ImplementationSpecific
+      backend:
+        service:
+          name: >-
+            {{ include "kubernetes-dashboard.fullname" . }}
+          port:
+            number: 443

--- a/aio/deploy/helm-chart/osm-dashboard/ci/ingress-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/ingress-values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  enabled: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/metrics-scraper-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/metrics-scraper-values.yaml
@@ -1,0 +1,11 @@
+rbac:
+  clusterRoleMetrics: true
+
+metricsScraper:
+  enabled: true
+
+metrics-server:
+  enabled: true
+  args:
+    - --kubelet-preferred-address-types=InternalIP
+    - --kubelet-insecure-tls

--- a/aio/deploy/helm-chart/osm-dashboard/ci/network-policy-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/network-policy-values.yaml
@@ -1,0 +1,2 @@
+networkPolicy:
+  enabled: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/pdb-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/pdb-values.yaml
@@ -1,0 +1,2 @@
+podDisruptionBudget:
+  enabled: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/podsecurity-policy-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/podsecurity-policy-values.yaml
@@ -1,0 +1,2 @@
+podSecurityPolicy:
+  enabled: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/rbac-cluster-readonly-role-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/rbac-cluster-readonly-role-values.yaml
@@ -1,0 +1,2 @@
+rbac:
+  clusterReadOnlyRole: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/servicemonitor-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/servicemonitor-values.yaml
@@ -1,0 +1,2 @@
+serviceMonitor:
+  enabled: true

--- a/aio/deploy/helm-chart/osm-dashboard/ci/settings-values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/ci/settings-values.yaml
@@ -1,0 +1,6 @@
+settings:
+  clusterName: "ci-cluster"
+  itemsPerPage: 10
+  logsAutoRefreshTimeInterval: 5
+  resourceAutoRefreshTimeInterval: 5
+  disableAccessDeniedNotifications: false

--- a/aio/deploy/helm-chart/osm-dashboard/templates/NOTES.txt
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/NOTES.txt
@@ -1,0 +1,49 @@
+*********************************************************************************
+*** PLEASE BE PATIENT: kubernetes-dashboard may take a few minutes to install ***
+*********************************************************************************
+
+{{- if .Values.ingress.enabled }}
+From outside the cluster, the server URL(s) are:
+{{- range .Values.ingress.hosts }}
+{{- if $.Values.protocolHttp }}
+     http://{{ . }}
+{{- else }}
+     https://{{ . }}
+{{- end }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+Get the Kubernetes Dashboard URL by running:
+  export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubernetes-dashboard.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- if .Values.protocolHttp }}
+  echo http://$NODE_IP:$NODE_PORT/
+{{- else }}
+  echo https://$NODE_IP:$NODE_PORT/
+{{- end }}
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -n {{ .Release.Namespace }} -w {{ template "kubernetes-dashboard.fullname" . }}'
+
+Get the Kubernetes Dashboard URL by running:
+  export SERVICE_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ template "kubernetes-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+{{- if .Values.protocolHttp }}
+  echo http://$SERVICE_IP/
+{{- else }}
+  echo https://$SERVICE_IP/
+{{- end }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+Get the Kubernetes Dashboard URL by running:
+  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kubernetes-dashboard.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+{{- if .Values.protocolHttp }}
+  echo http://127.0.0.1:9090/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090:9090
+{{- else }}
+  echo https://127.0.0.1:8443/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8443:8443
+{{- end }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/_helpers.tpl
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-dashboard.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-dashboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-dashboard.labels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-dashboard.name" . }}
+helm.sh/chart: {{ include "kubernetes-dashboard.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common label selectors
+*/}}
+{{- define "kubernetes-dashboard.matchLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-dashboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the service account to use
+*/}}
+{{- define "kubernetes-dashboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kubernetes-dashboard.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/_tplvalues.tpl
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/_tplvalues.tpl
@@ -1,0 +1,27 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/clusterrole-metrics.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/clusterrole-metrics.yaml
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.clusterRoleMetrics -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}-metrics"
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+  # Allow Metrics Scraper to get metrics from the Metrics server
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/clusterrole-readonly.yaml
@@ -1,0 +1,154 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.clusterReadOnlyRole -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}-readonly"
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - persistentvolumeclaims
+      - pods
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - serviceaccounts
+      - services
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - events
+      - limitranges
+      - namespaces/status
+      - pods/log
+      - pods/status
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - replicasets
+      - replicasets/scale
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - ingresses
+      - networkpolicies
+      - replicasets
+      - replicasets/scale
+      - replicationcontrollers/scale
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/clusterrolebinding-metrics.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/clusterrolebinding-metrics.yaml
@@ -1,0 +1,37 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.clusterRoleMetrics -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}-metrics"
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubernetes-dashboard.fullname" . }}-metrics
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/clusterrolebinding-readonly.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/clusterrolebinding-readonly.yaml
@@ -1,0 +1,37 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.clusterReadOnlyRole -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-readonly
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubernetes-dashboard.fullname" . }}-readonly
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/configmap.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/configmap.yaml
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: kubernetes-dashboard-settings
+data:
+{{- with .Values.settings }}
+  _global: {{ toJson . | quote }}
+{{- end }}
+{{- with .Values.pinnedCRDs }}
+  _pinnedCRD: {{ toJson . | quote }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/deployment.yaml
@@ -1,0 +1,188 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- with .Values.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-dashboard
+    {{- with .Values.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kubernetes-dashboard
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "kubernetes-dashboard.labels" . | nindent 8 }}
+        app.kubernetes.io/component: kubernetes-dashboard
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - --namespace={{ .Release.Namespace }}
+{{- if not .Values.protocolHttp }}
+          - --auto-generate-certificates
+{{- end }}
+{{- if .Values.metricsScraper.enabled }}
+          - --sidecar-host=http://127.0.0.1:8000
+{{- else }}
+          - --metrics-provider=none
+{{- end }}
+{{- with .Values.extraArgs }}
+{{ toYaml . | nindent 10 }}
+{{- end }}
+{{- with .Values.extraEnv }}
+        env:
+{{ toYaml . | nindent 10 }}
+{{- end }}
+        ports:
+{{- if .Values.protocolHttp }}
+        - name: http
+          containerPort: 9090
+          protocol: TCP
+{{- else }}
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+{{- end }}
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+{{- if .Values.protocolHttp }}
+            scheme: HTTP
+            path: /
+            port: 9090
+{{- else }}
+            scheme: HTTPS
+            path: /
+            port: 8443
+{{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- with .Values.resources }}
+        resources:
+{{ toYaml . | nindent 10 }}
+{{- end }}
+{{- with .Values.containerSecurityContext }}
+        securityContext:
+{{ toYaml . | nindent 10 }}
+{{- end }}
+{{- if .Values.metricsScraper.enabled }}
+      - name: dashboard-metrics-scraper
+        image: "{{ .Values.metricsScraper.image.repository }}:{{ .Values.metricsScraper.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- with .Values.metricsScraper.args }}
+        args:
+{{ toYaml . | nindent 10 }}
+{{- end }}
+        ports:
+          - containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /
+            port: 8000
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+
+{{- if .Values.metricsScraper.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.metricsScraper.containerSecurityContext | nindent 10 }}
+{{- else if .Values.containerSecurityContext}}
+        securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 10 }}
+{{- end }}
+{{- with .Values.metricsScraper.resources }}
+        resources:
+{{ toYaml . | nindent 10 }}
+{{- end }}
+{{- end }}
+{{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- range . }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.priorityClassName }}
+      priorityClassName: "{{ . }}"
+{{- end }}
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: {{ template "kubernetes-dashboard.fullname" . }}-certs
+      - name: tmp-volume
+        emptyDir: {}
+{{- with .Values.extraVolumes }}
+{{ toYaml . | nindent 6 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | nindent 8 }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/extra-manifests.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/ingress.yaml
@@ -1,0 +1,89 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.ingress.enabled -}}
+{{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $paths := .Values.ingress.paths -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if not .Values.protocolHttp }}
+    # Add https backend protocol support for ingress-nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # Add https backend protocol support for GKE
+    service.alpha.kubernetes.io/app-protocols: '{"https":"HTTPS"}'
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  rules:
+  {{- if .Values.ingress.hosts }}
+  {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+  {{- if len ($.Values.ingress.customPaths) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.customPaths | nindent 10) $ }}
+  {{- else }}
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+  {{- if len ($.Values.ingress.customPaths) }}
+  {{- "\n" }}{{ tpl (toYaml $.Values.ingress.customPaths | nindent 10) $ }}
+  {{- else }}
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/networkpolicy.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    app: {{ template "kubernetes-dashboard.name" . }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+  ingress:
+  - ports:
+{{- if .Values.protocolHttp }}
+    - port: http
+      protocol: TCP
+{{- else }}
+    - port: https
+      protocol: TCP
+{{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/pdb.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/pdb.yaml
@@ -1,0 +1,39 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | nindent 6 }}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/psp.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/psp.yaml
@@ -1,0 +1,82 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-psp
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  privileged: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  runAsGroup:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'emptyDir'
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-psp
+  labels:
+{{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-dashboard.fullname" . }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-psp
+  labels:
+{{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - extensions
+  - policy/v1beta1
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "kubernetes-dashboard.fullname" . }}-psp
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/role.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/role.yaml
@@ -1,0 +1,49 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+rules:
+    # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    verbs: ["get", "update", "delete"]
+    # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["kubernetes-dashboard-settings"]
+    verbs: ["get", "update"]
+    # Allow Dashboard to get metrics.
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    verbs: ["proxy"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    verbs: ["get"]
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/rolebinding.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/rolebinding.yaml
@@ -1,0 +1,37 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/secret.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/secret.yaml
@@ -1,0 +1,47 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# kubernetes-dashboard-certs
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-certs
+type: Opaque
+---
+# kubernetes-dashboard-csrf
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: kubernetes-dashboard-csrf
+type: Opaque
+---
+# kubernetes-dashboard-key-holder
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+  name: kubernetes-dashboard-key-holder
+type: Opaque

--- a/aio/deploy/helm-chart/osm-dashboard/templates/service.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/service.yaml
@@ -1,0 +1,62 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    {{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-dashboard
+    {{ .Values.service.clusterServiceLabel.key | nindent 4}}: {{ .Values.service.clusterServiceLabel.enabled | quote }}
+    {{- if .Values.service.labels }}
+    {{ toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations }}
+    {{ toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if hasKey .Values.service "clusterIP" }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+{{- if .Values.protocolHttp }}
+    targetPort: http
+    name: http
+{{- else }}
+    targetPort: https
+    name: https
+{{- end }}
+{{- if hasKey .Values.service "nodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+  selector:
+{{ include "kubernetes-dashboard.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-dashboard
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/serviceaccount.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/serviceaccount.yaml
@@ -1,0 +1,29 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "kubernetes-dashboard.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+{{- end -}}

--- a/aio/deploy/helm-chart/osm-dashboard/templates/servicemonitor.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/templates/servicemonitor.yaml
@@ -1,0 +1,44 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    {{ include "kubernetes-dashboard.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubernetes-dashboard
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    {{- if .Values.protocolHttp }}
+    - port: http
+    {{- else }}
+    - port: https
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    {{- end }}
+      path: /metrics
+  selector:
+    matchLabels:
+      {{ include "kubernetes-dashboard.labels" . | nindent 6 }}
+{{- end }}

--- a/aio/deploy/helm-chart/osm-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/osm-dashboard/values.yaml
@@ -1,0 +1,347 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for kubernetes-dashboard
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+image:
+  ## Repository for container
+  repository: flomesh/osm-dashboard
+  tag: v2.5.1
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+## Number of replicas
+replicaCount: 1
+
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+
+## Here annotations can be added to the kubernetes dashboard deployment
+annotations: {}
+## Here labels can be added to the kubernetes dashboard deployment
+labels: {}
+
+## Additional container arguments
+##
+# extraArgs:
+#   - --enable-skip-login
+#   - --enable-insecure-login
+#   - --system-banner="Welcome to Kubernetes"
+
+## Additional container environment variables
+##
+extraEnv: []
+# - name: SOME_VAR
+#   value: 'some value'
+
+## Additional volumes to be added to kubernetes dashboard pods
+##
+extraVolumes: []
+# - name: dashboard-kubeconfig
+#   secret:
+#     defaultMode: 420
+#     secretName: dashboard-kubeconfig
+
+## Additional volumeMounts to be added to kubernetes dashboard container
+##
+extraVolumeMounts: []
+# - mountPath: /kubeconfig
+#   name: dashboard-kubeconfig
+#   readOnly: true
+
+## Array of extra K8s manifests to deploy
+##
+extraManifests: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: additional-configmap
+#   data:
+#     mykey: myvalue
+
+## Annotations to be added to kubernetes dashboard pods
+# podAnnotations:
+
+## SecurityContext to be added to kubernetes dashboard pods
+## To disable set the following configuration to null:
+# securityContext: null
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+## SecurityContext defaults for the kubernetes dashboard container and metrics scraper container
+## To disable set the following configuration to null:
+# containerSecurityContext: null
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1001
+  runAsGroup: 2001
+
+## @param podLabels Extra labels for OAuth2 Proxy pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param podAnnotations Annotations for OAuth2 Proxy pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+tolerations: []
+#  - key: "key"
+#    operator: "Equal|Exists"
+#    value: "value"
+#    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Name of Priority Class of pods
+# priorityClassName: ""
+
+## Pod resource requests & limits
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 2
+    memory: 200Mi
+
+## Serve application over HTTP without TLS
+##
+## Note: If set to true, you may want to add --enable-insecure-login to extraArgs
+protocolHttp: false
+
+service:
+  type: ClusterIP
+  # Dashboard service port
+  externalPort: 443
+
+  ## LoadBalancerSourcesRange is a list of allowed CIDR values, which are combined with ServicePort to
+  ## set allowed inbound rules on the security group assigned to the master load balancer
+  # loadBalancerSourceRanges: []
+
+  # clusterIP: ""
+
+  ## A user-specified IP address for load balancer to use as External IP (if supported)
+  # loadBalancerIP:
+
+  ## Additional Kubernetes Dashboard Service annotations
+  annotations: {}
+
+  ## Here labels can be added to the Kubernetes Dashboard service
+  labels: {}
+
+  ## Enable or disable the kubernetes.io/cluster-service label. Should be disabled for GKE clusters >=1.15.
+  ## Otherwise, the addon manager will presume ownership of the service and try to delete it.
+  clusterServiceLabel:
+    enabled: true
+    key: "kubernetes.io/cluster-service"
+
+ingress:
+  ## If true, Kubernetes Dashboard Ingress will be created.
+  ##
+  enabled: false
+
+  ## Kubernetes Dashboard Ingress labels
+  # labels:
+  #   key: value
+
+  ## Kubernetes Dashboard Ingress annotations
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: 'true'
+
+  ## If you plan to use TLS backend with enableInsecureLogin set to false
+  ## (default), you need to uncomment the below.
+  ## If you use ingress-nginx < 0.21.0
+  #   nginx.ingress.kubernetes.io/secure-backends: "true"
+  ## if you use ingress-nginx >= 0.21.0
+  #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
+  ## Kubernetes Dashboard Ingress Class
+  # className: "example-lb"
+
+  ## Kubernetes Dashboard Ingress paths
+  ## Both `/` and `/*` are required to work on gce ingress.
+  paths:
+    - /
+  #  - /*
+
+  ## Custom Kubernetes Dashboard Ingress paths. Will override default paths.
+  ##
+  customPaths: []
+  #  - pathType: ImplementationSpecific
+  #    backend:
+  #      service:
+  #        name: ssl-redirect
+  #        port:
+  #          name: use-annotation
+  #  - pathType: ImplementationSpecific
+  #    backend:
+  #      service:
+  #        name: >-
+  #          {{ include "kubernetes-dashboard.fullname" . }}
+  #        port:
+  #          # Don't use string here, use only integer value!
+  #          number: 443
+  ## Kubernetes Dashboard Ingress hostnames
+  ## Must be provided if Ingress is enabled
+  ##
+  # hosts:
+  #   - kubernetes-dashboard.domain.com
+  ## Kubernetes Dashboard Ingress TLS configuration
+  ## Secrets must be manually created in the namespace
+  ##
+  # tls:
+  #   - secretName: kubernetes-dashboard-tls
+  #     hosts:
+  #       - kubernetes-dashboard.domain.com
+
+# Global dashboard settings
+settings:
+  {}
+  ## Cluster name that appears in the browser window title if it is set
+  # clusterName: ""
+  ## Max number of items that can be displayed on each list page
+  # itemsPerPage: 10
+  ## Number of seconds between every auto-refresh of logs
+  # logsAutoRefreshTimeInterval: 5
+  ## Number of seconds between every auto-refresh of every resource. Set 0 to disable
+  # resourceAutoRefreshTimeInterval: 5
+  ## Hide all access denied warnings in the notification panel
+  # disableAccessDeniedNotifications: false
+
+## Pinned CRDs that will be displayed in dashboard's menu
+pinnedCRDs:
+  []
+  # - kind: customresourcedefinition
+  ##  Fully qualified name of a CRD
+  #   name: prometheuses.monitoring.coreos.com
+  ##  Display name
+  #   displayName: Prometheus
+  ##  Is this CRD namespaced?
+  #   namespaced: true
+
+## Metrics Scraper
+## Container to scrape, store, and retrieve a window of time from the Metrics Server.
+## refs: https://github.com/kubernetes-sigs/dashboard-metrics-scraper
+metricsScraper:
+  ## Wether to enable dashboard-metrics-scraper
+  enabled: false
+  image:
+    repository: kubernetesui/metrics-scraper
+    tag: v1.0.8
+  resources: {}
+  ## SecurityContext especially for the kubernetes dashboard metrics scraper container
+  ## If not set, the global containterSecurityContext values will define these values
+  # containerSecurityContext:
+  #   allowPrivilegeEscalation: false
+  #   readOnlyRootFilesystem: true
+  #   runAsUser: 1001
+  #   runAsGroup: 2001
+#  args:
+#    - --log-level=info
+#    - --logtostderr=true
+
+## Optional Metrics Server sub-chart
+## Enable this if you don't already have metrics-server enabled on your cluster and
+## want to use it with dashboard metrics-scraper
+## refs:
+##  - https://github.com/kubernetes-sigs/metrics-server
+##  - https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
+metrics-server:
+  enabled: false
+  ## Example for additional args
+  # args:
+  #  - --kubelet-preferred-address-types=InternalIP
+  #  - --kubelet-insecure-tls
+
+rbac:
+  # Specifies whether namespaced RBAC resources (Role, Rolebinding) should be created
+  create: true
+
+  # Specifies whether cluster-wide RBAC resources (ClusterRole, ClusterRolebinding) to access metrics should be created
+  # Independent from rbac.create parameter.
+  clusterRoleMetrics: true
+
+  # Start in ReadOnly mode.
+  # Specifies whether cluster-wide RBAC resources (ClusterRole, ClusterRolebinding) with read only permissions to all resources listed inside the cluster should be created
+  # Only dashboard-related Secrets and ConfigMaps will still be available for writing.
+  #
+  # The basic idea of the clusterReadOnlyRole
+  # is not to hide all the secrets and sensitive data but more
+  # to avoid accidental changes in the cluster outside the standard CI/CD.
+  #
+  # It is NOT RECOMMENDED to use this version in production.
+  # Instead you should review the role and remove all potentially sensitive parts such as
+  # access to persistentvolumes, pods/log etc.
+  #
+  # Independent from rbac.create parameter.
+  clusterReadOnlyRole: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+livenessProbe:
+  # Number of seconds to wait before sending first probe
+  initialDelaySeconds: 30
+  # Number of seconds to wait for probe response
+  timeoutSeconds: 30
+
+## podDisruptionBudget
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  ## Minimum available instances; ignored if there is no PodDisruptionBudget
+  minAvailable:
+  ## Maximum unavailable instances; ignored if there is no PodDisruptionBudget
+  maxUnavailable:
+
+## PodSecurityContext for pod level securityContext
+# securityContext:
+#   runAsUser: 1001
+#   runAsGroup: 2001
+
+networkPolicy:
+  # Whether to create a network policy that allows/restricts access to the service
+  enabled: false
+
+## podSecurityPolicy for fine-grained authorization of pod creation and updates
+podSecurityPolicy:
+  # Specifies whether a pod security policy should be created
+  enabled: false
+
+serviceMonitor:
+  # Whether or not to create a Prometheus Operator service monitor.
+  enabled: false

--- a/aio/scripts/helm-release-chart.sh
+++ b/aio/scripts/helm-release-chart.sh
@@ -23,7 +23,7 @@ ROOT_DIR="$(cd $(dirname "${BASH_SOURCE}")/../.. && pwd -P)"
 . "${ROOT_DIR}/aio/scripts/conf.sh"
 
 # Declare variables.
-HELM_CHART_DIR="$AIO_DIR/deploy/helm-chart/kubernetes-dashboard"
+HELM_CHART_DIR="$AIO_DIR/deploy/helm-chart/osm-dashboard"
 
 function release-helm-chart {
   if [ -n "$(git status --porcelain)" ]; then
@@ -42,10 +42,10 @@ function release-helm-chart {
   say "\nGenerating new Helm index, containing all existing versions in gh-pages (previous ones + new one)."
   helm repo index . --merge $ROOT_DIR/index.yaml
   mv index.yaml $ROOT_DIR/index.yaml
-  mv kubernetes-dashboard-*.tgz $ROOT_DIR
+  mv osm-dashboard-*.tgz $ROOT_DIR
   cd $OLDPWD
   say "\nCommit new package and index."
-  git add -A "./kubernetes-dashboard-*.tgz" ./index.yaml && git commit -m "Update Helm repository from CI."
+  git add -A "./osm-dashboard-*.tgz" ./index.yaml && git commit -m "Update Helm repository from CI."
   say "\nIf you are happy with the changes, please manually push to the gh-pages branch. No force should be needed."
   say "Assuming upstream is your remote, please run: git push upstream gh-pages."
 }


### PR DESCRIPTION
Congfiture CI/CD for these actions:

* trigger ci-workflow, ci-helm-workflow, cd-workflow, cd-helm-workflow on `osm-*` branch
* non-tagged version will be push to `osm-dashboard-nightly:latest`
* tagged version will be push to `osm-dashboard:<tag>`

If chart version update needed, modify `aio/deploy/helm-chart/osm-dashboard/Chart.yaml` before tagging